### PR TITLE
Fix the one character that prevented XGE events from working

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breadx"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["notgull <jtnunley01@gmail.com>"]
 edition = "2018"
 description = "Implementation of the X Window System Protocol"

--- a/src/display/input.rs
+++ b/src/display/input.rs
@@ -11,7 +11,7 @@ use super::AsyncConnection;
 
 const TYPE_ERROR: u8 = 0;
 const TYPE_REPLY: u8 = 1;
-const GENERIC_EVENT: u8 = 32;
+const GENERIC_EVENT: u8 = 35;
 const GE_MASK: u8 = 0x7f;
 
 impl<Conn> super::Display<Conn> {


### PR DESCRIPTION
Who forgot to read the docs? This guy did!

Apparently, when I was originally setting up the input code, I'd somehow convinced myself that the opcode used for XGE events (read: the value you compare the first byte AND'd with 0x7f to whenever you need to determine whether or not it's an XGE event) is 32. I've spent the past few days trying to debug some code that uses XGE pretty extensively, only to find out that it's actually 35.