### PR TITLE
Add bigreq support to both current display types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ image-support = ["image", "std"]
 std = ["memchr/std"]
 
 # Extensions
-bigreq = []
 damage = ["fixes"]
 dpms = []
 dri2 = []
@@ -70,7 +69,7 @@ xkb = []
 xtest = []
 xvmc = ["xv"]
 xv = ["shm"]
-all-extensions = ["bigreq", "damage", "dpms", "dri2", "dri3", "fixes", "ge", "glx", "input", "present", "print", "randr", "record", "render", "res", "screensaver", "selinux", "shape", "shm", "sync", "xevie", "xf86dri", "xf86vidmode", "xinerama", "xkb", "xtest", "xvmc", "xv"]
+all-extensions = ["damage", "dpms", "dri2", "dri3", "fixes", "ge", "glx", "input", "present", "print", "randr", "record", "render", "res", "screensaver", "selinux", "shape", "shm", "sync", "xevie", "xf86dri", "xf86vidmode", "xinerama", "xkb", "xtest", "xvmc", "xv"]
 
 [package.metadata.docs.rs]
 features = ["async", "all-extensions"]

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -337,7 +337,6 @@ impl AsByteSequence for String {
     }
 }
 
-#[cfg(feature = "bigreq")]
 pub mod bigreq;
 #[cfg(feature = "damage")]
 pub mod damage;

--- a/src/display/bigreq.rs
+++ b/src/display/bigreq.rs
@@ -1,0 +1,43 @@
+// MIT/Apache2 License
+
+//! Functions to handle `bigreq` functionality.
+
+use super::{prelude::*, Display};
+use crate::auto::bigreq::EnableRequest;
+
+#[cfg(feature = "async")]
+use super::{
+    futures::{ExchangeRequestFuture, MapFuture},
+    AsyncDisplay,
+};
+#[cfg(feature = "async")]
+use crate::auto::bigreq::EnableReply;
+
+/// Try to enable `bigreq` for this display.
+#[inline]
+pub(crate) fn try_bigreq<D: Display + ?Sized>(display: &mut D) -> crate::Result<Option<u32>> {
+    match display.exchange_request(EnableRequest::default()) {
+        Ok(repl) => Ok(Some(repl.maximum_request_length)),
+        Err(crate::BreadError::ExtensionNotPresent(_)) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Try to enable `bigreq` for this display, async redox.
+#[cfg(feature = "async")]
+#[inline]
+pub(crate) fn try_bigreq_async<D: AsyncDisplay + ?Sized>(
+    display: &mut D,
+) -> MapFuture<
+    ExchangeRequestFuture<'_, D, EnableRequest>,
+    fn(crate::Result<EnableReply>) -> crate::Result<Option<u32>>,
+> {
+    MapFuture::run(
+        display.exchange_request_async(EnableRequest::default()),
+        |repl| match repl {
+            Ok(repl) => Ok(Some(repl.maximum_request_length)),
+            Err(crate::BreadError::ExtensionNotPresent(_)) => Ok(None),
+            Err(e) => Err(e),
+        },
+    )
+}

--- a/src/display/cell.rs
+++ b/src/display/cell.rs
@@ -63,6 +63,12 @@ pub struct CellDisplay<Conn> {
     // xid generator
     xid: CellXidGenerator,
 
+    // whether or not bigreq is enabled
+    bigreq_enabled: bool,
+
+    // maximum request length
+    max_request_len: usize,
+
     // the screen to be used by default
     default_screen: usize,
 
@@ -107,6 +113,8 @@ impl<Conn> From<BasicDisplay<Conn>> for CellDisplay<Conn> {
             connection,
             setup,
             xid,
+            bigreq_enabled,
+            max_request_len,
             default_screen,
             event_queue,
             pending_requests,
@@ -125,6 +133,8 @@ impl<Conn> From<BasicDisplay<Conn>> for CellDisplay<Conn> {
             io_lock: Cell::new(false),
             setup,
             xid: xid.into(),
+            bigreq_enabled,
+            max_request_len,
             default_screen,
             inner: RefCell::new(Data {
                 event_queue,
@@ -270,6 +280,14 @@ impl<Conn> DisplayBase for CellDisplay<Conn> {
     #[inline]
     fn set_checked(&mut self, checked: bool) {
         *self.checked.get_mut() = checked;
+    }
+    #[inline]
+    fn bigreq_enabled(&self) -> bool {
+        self.bigreq_enabled
+    }
+    #[inline]
+    fn max_request_len(&self) -> usize {
+        self.max_request_len
     }
     #[inline]
     fn get_extension_opcode(&mut self, key: &[u8; EXT_KEY_SIZE]) -> Option<u8> {
@@ -479,6 +497,14 @@ impl<'a, Conn> DisplayBase for &'a CellDisplay<Conn> {
     #[inline]
     fn set_checked(&mut self, checked: bool) {
         self.checked.set(checked);
+    }
+    #[inline]
+    fn bigreq_enabled(&self) -> bool {
+        self.bigreq_enabled
+    }
+    #[inline]
+    fn max_request_len(&self) -> usize {
+        self.max_request_len
     }
     #[inline]
     fn get_extension_opcode(&mut self, key: &[u8; EXT_KEY_SIZE]) -> Option<u8> {

--- a/src/display/common.rs
+++ b/src/display/common.rs
@@ -289,15 +289,17 @@ impl SendBuffer {
                                         req,
                                         InnerSendBuffer::new_internal(
                                             {
-                                                let mut qer = output::preprocess_request(
-                                                    display,
-                                                    RequestInfo::from_request(
-                                                        QueryExtensionRequest {
-                                                            name: String::from(extension),
-                                                            ..Default::default()
-                                                        },
-                                                    ),
+                                                let qer = RequestInfo::from_request(
+                                                    QueryExtensionRequest {
+                                                        name: String::from(extension),
+                                                        ..Default::default()
+                                                    },
+                                                    display.bigreq_enabled(),
+                                                    display.max_request_len(),
                                                 );
+
+                                                let mut qer =
+                                                    output::preprocess_request(display, qer);
                                                 output::modify_for_opcode(
                                                     &mut qer.data,
                                                     qer.opcode,

--- a/src/display/futures/send_request.rs
+++ b/src/display/futures/send_request.rs
@@ -27,8 +27,10 @@ impl<'a, D: AsyncDisplay + ?Sized, R: Request> SendRequestFuture<'a, D, R> {
     pub(crate) fn run(display: &'a mut D, request: R) -> Self {
         log::info!("Sending a {} to the server", core::any::type_name::<R>());
 
+        let req =
+            RequestInfo::from_request(request, display.bigreq_enabled(), display.max_request_len());
         Self {
-            inner: SendRequestRawFuture::run(display, RequestInfo::from_request(request)),
+            inner: SendRequestRawFuture::run(display, req),
             _phantom: PhantomData,
         }
     }

--- a/src/display/futures/synchronize.rs
+++ b/src/display/futures/synchronize.rs
@@ -47,7 +47,11 @@ impl<'a, D: AsyncDisplay + ?Sized> SynchronizeFuture<'a, D> {
     pub(crate) fn run(display: &'a mut D) -> Self {
         log::debug!("Beginning synchronization process");
 
-        let mut gifr = RequestInfo::from_request(GetInputFocusRequest::default());
+        let mut gifr = RequestInfo::from_request(
+            GetInputFocusRequest::default(),
+            display.bigreq_enabled(),
+            display.max_request_len(),
+        );
         gifr.discard_reply = true;
 
         SynchronizeFuture::Sending {

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -665,12 +665,12 @@ impl RequestInfo {
         // If we fit in the short request limit, third and fourth bytes need to be length
         let x_len = len / 4;
         log::trace!("xlen is {}", x_len);
-        if max_request_len <= SHORT_REQUEST_LIMIT {
+        if !use_bigreq {
             let len_bytes = (x_len as u16).to_ne_bytes();
             data[2] = len_bytes[0];
             data[3] = len_bytes[1];
         } else {
-            let length_bytes = (x_len as u32).to_ne_bytes();
+            let length_bytes = ((x_len + 1) as u32).to_ne_bytes();
             data = match data {
                 TinyVec::Inline(data) => BigreqIterator {
                     inner: data.into_iter(),

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -665,11 +665,7 @@ impl RequestInfo {
         // If we fit in the short request limit, third and fourth bytes need to be length
         let x_len = len / 4;
         log::trace!("xlen is {}", x_len);
-        if !use_bigreq {
-            let len_bytes = (x_len as u16).to_ne_bytes();
-            data[2] = len_bytes[0];
-            data[3] = len_bytes[1];
-        } else {
+        if use_bigreq {
             let length_bytes = ((x_len + 1) as u32).to_ne_bytes();
             data = match data {
                 TinyVec::Inline(data) => BigreqIterator {
@@ -685,6 +681,10 @@ impl RequestInfo {
                 }
                 .collect(),
             };
+        } else {
+            let len_bytes = (x_len as u16).to_ne_bytes();
+            data[2] = len_bytes[0];
+            data[3] = len_bytes[1];
         }
 
         RequestInfo {

--- a/src/display/output.rs
+++ b/src/display/output.rs
@@ -139,7 +139,11 @@ pub(crate) fn get_ext_opcode<D: Display + ?Sized, C: Connection + ?Sized>(
     };
 
     log_trace!("Sending QER..");
-    let tok = send_request(display, conn, RequestInfo::from_request(qer))?;
+    let tok = send_request(
+        display,
+        conn,
+        RequestInfo::from_request(qer, display.bigreq_enabled(), display.max_request_len()),
+    )?;
     log_trace!("Resolving QER...");
     let repl = loop {
         match display.take_pending_reply(tok) {

--- a/src/render/display.rs
+++ b/src/render/display.rs
@@ -336,6 +336,15 @@ impl<Dpy: DisplayBase> DisplayBase for RenderDisplay<Dpy> {
     }
 
     #[inline]
+    fn bigreq_enabled(&self) -> bool {
+        self.inner.bigreq_enabled()
+    }
+    #[inline]
+    fn max_request_len(&self) -> usize {
+        self.inner.max_request_len()
+    }
+
+    #[inline]
     fn get_extension_opcode(&mut self, key: &[u8; EXT_KEY_SIZE]) -> Option<u8> {
         self.inner.get_extension_opcode(key)
     }
@@ -453,6 +462,15 @@ where
     #[inline]
     fn set_checked(&mut self, checked: bool) {
         self.inner().set_checked(checked);
+    }
+
+    #[inline]
+    fn bigreq_enabled(&self) -> bool {
+        self.inner.bigreq_enabled()
+    }
+    #[inline]
+    fn max_request_len(&self) -> usize {
+        self.inner.max_request_len()
     }
 
     #[inline]


### PR DESCRIPTION
This pull request adds two new methods to `DisplayBase` trait: `bigreq_enabled` and `max_request_len`. It also modified `StandardDisplay` to try to enable `bigreq` on startup. In addition, the API of `RequestInfo::from_request` is modified accordingly.