### PR TITLE
Add the `sync-display` feature and the `SyncDisplay` object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ async-net = { version = "1.5.0", optional = true }
 blocking = { version = "1.0.2", optional = true }
 bytemuck = "1.4.1"
 cfg-if = "1"
+concurrent-queue = { version = "1.2", optional = true }
+dashmap = { version = "4", optional = true }
 cty = "0.2.1"
 futures-lite = { version = "1.11.2", optional = true }
 gluten-keyboard = "0.1.2"
@@ -22,6 +24,7 @@ image = { version = "0.23.12", default-features = false, optional = true }
 log = "0.4"
 memchr = { version = "2.3.3", default-features = false }
 pin-project-lite = { version = "0.2", optional = true }
+spinning_top = { version = "0.2", optional = true }
 tinyvec = { version = "1.1.0", features = ["alloc"] }
 
 [target.'cfg(unix)'.dependencies]
@@ -40,6 +43,7 @@ default = ["std"]
 async = ["std", "async-io", "async-net", "blocking", "futures-lite", "pin-project-lite"]
 image-support = ["image", "std"]
 std = ["memchr/std"]
+sync = ["concurrent-queue", "dashmap", "spinning_top", "std"]
 
 # Extensions
 damage = ["fixes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default = ["std"]
 async = ["std", "async-io", "async-net", "blocking", "futures-lite", "pin-project-lite"]
 image-support = ["image", "std"]
 std = ["memchr/std"]
-sync = ["concurrent-queue", "dashmap", "spinning_top", "std"]
+sync-display = ["concurrent-queue", "dashmap", "spinning_top", "std"]
 
 # Extensions
 damage = ["fixes"]

--- a/src/display/basic.rs
+++ b/src/display/basic.rs
@@ -59,7 +59,6 @@ pub struct BasicDisplay<Conn> {
     pub(crate) event_queue: VecDeque<Event>,
     /// Map associating request numbers to pending requests, that have not been replied to by
     /// the server yet.
-    /// TODO: maybe combine into one HashMap that uses an enum?
     pub(crate) pending_requests: HashMap<u16, PendingRequest>,
     /// Map associating request numbers to requests that have error'd out. This map is unlikely
     /// to ever hold many entries; it might be worth reconsidering its type.

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -41,9 +41,9 @@ pub(crate) mod futures;
 #[cfg(feature = "async")]
 pub use futures::*;
 
-#[cfg(feature = "sync")]
+#[cfg(feature = "sync-display")]
 mod sync;
-#[cfg(feature = "sync")]
+#[cfg(feature = "sync-display")]
 pub use sync::*;
 
 pub(crate) mod input;
@@ -88,35 +88,23 @@ pub trait DisplayBase {
     /// Generate the next request number to be used to define a request.
     fn next_request_number(&mut self) -> u64;
 
+    /// Generate an XID within appropriate bounds. Returns `None` if our XIDs are exhausted.
+    fn generate_xid(&mut self) -> Option<XID>;
+
+    /// Add a `PendingItem` to this display's map.
+    fn add_pending_item(&mut self, req_id: u16, item: PendingItem);
+
+    /// Clone a `PendingItem` from this display's map and return it.
+    fn get_pending_item(&mut self, req_id: u16) -> Option<PendingItem>;
+
+    /// Remove a `PendingItem` from this display's map.
+    fn take_pending_item(&mut self, req_id: u16) -> Option<PendingItem>;
+
     /// Push an event into this display's event queue.
     fn push_event(&mut self, event: Event);
 
     /// Pop an event from this display's event queue.
     fn pop_event(&mut self) -> Option<Event>;
-
-    /// Generate an XID within appropriate bounds. Returns `None` if our XIDs are exhausted.
-    fn generate_xid(&mut self) -> Option<XID>;
-
-    /// Add a pending request to this display.
-    fn add_pending_request(&mut self, req_id: u16, pereq: PendingRequest);
-
-    /// Get a pending request from this display.
-    fn get_pending_request(&self, req_id: u16) -> Option<PendingRequest>;
-
-    /// Remove a pending request from this display.
-    fn take_pending_request(&mut self, req_id: u16) -> Option<PendingRequest>;
-
-    /// Add a pending error to this display.
-    fn add_pending_error(&mut self, req_id: u16, error: BreadError);
-
-    /// Remove a pending error, if it exists.
-    fn check_for_pending_error(&mut self, req_id: u16) -> crate::Result<()>;
-
-    /// Add a pending reply.
-    fn add_pending_reply(&mut self, req_id: u16, reply: PendingReply);
-
-    /// Remove the pending reply.
-    fn take_pending_reply(&mut self, req_id: u16) -> Option<PendingReply>;
 
     /// Create a new special event queue.
     fn create_special_event_queue(&mut self, xid: XID);
@@ -154,6 +142,54 @@ pub trait DisplayBase {
 
     /// Set the `WM_PROTOCOLS` atom.
     fn set_wm_protocols_atom(&mut self, a: NonZeroU32);
+
+    // -- Item-based functions.
+
+    /// Insert a pending request into this display.
+    #[inline]
+    fn add_pending_request(&mut self, req_id: u16, pereq: PendingRequest) {
+        self.add_pending_item(req_id, PendingItem::Request(pereq));
+    }
+
+    /// Get a pending request from this display.
+    #[inline]
+    fn get_pending_request(&mut self, req_id: u16) -> Option<PendingRequest> {
+        self.get_pending_item(req_id).and_then(PendingItem::request)
+    }
+
+    /// Take a pending request from this display.
+    #[inline]
+    fn take_pending_request(&mut self, req_id: u16) -> Option<PendingRequest> {
+        self.take_pending_item(req_id)
+            .and_then(PendingItem::request)
+    }
+
+    /// Insert a pending reply into this display.
+    #[inline]
+    fn add_pending_reply(&mut self, req_id: u16, perep: PendingReply) {
+        self.add_pending_item(req_id, PendingItem::Reply(perep));
+    }
+
+    /// Take a pending reply from this display.
+    #[inline]
+    fn take_pending_reply(&mut self, req_id: u16) -> Option<PendingReply> {
+        self.take_pending_item(req_id).and_then(PendingItem::reply)
+    }
+
+    /// Insert a pending error into this display.
+    #[inline]
+    fn add_pending_error(&mut self, req_id: u16, err: BreadError) {
+        self.add_pending_item(req_id, PendingItem::Error(err));
+    }
+
+    /// Check this display for the pending error.
+    #[inline]
+    fn check_for_pending_error(&mut self, req_id: u16) -> crate::Result {
+        match self.take_pending_item(req_id) {
+            Some(PendingItem::Error(err)) => Err(err),
+            _ => Ok(()),
+        }
+    }
 
     // -- Setup-based functions.
 
@@ -264,38 +300,18 @@ impl<D: DisplayBase + ?Sized> DisplayBase for &mut D {
     }
 
     #[inline]
-    fn add_pending_request(&mut self, req_id: u16, pereq: PendingRequest) {
-        (**self).add_pending_request(req_id, pereq)
+    fn add_pending_item(&mut self, req_id: u16, item: PendingItem) {
+        (**self).add_pending_item(req_id, item)
     }
 
     #[inline]
-    fn get_pending_request(&self, req_id: u16) -> Option<PendingRequest> {
-        (**self).get_pending_request(req_id)
+    fn get_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
+        (**self).get_pending_item(req_id)
     }
 
     #[inline]
-    fn take_pending_request(&mut self, req_id: u16) -> Option<PendingRequest> {
-        (**self).take_pending_request(req_id)
-    }
-
-    #[inline]
-    fn add_pending_error(&mut self, req_id: u16, error: BreadError) {
-        (**self).add_pending_error(req_id, error)
-    }
-
-    #[inline]
-    fn check_for_pending_error(&mut self, req_id: u16) -> crate::Result<()> {
-        (**self).check_for_pending_error(req_id)
-    }
-
-    #[inline]
-    fn add_pending_reply(&mut self, req_id: u16, reply: PendingReply) {
-        (**self).add_pending_reply(req_id, reply)
-    }
-
-    #[inline]
-    fn take_pending_reply(&mut self, req_id: u16) -> Option<PendingReply> {
-        (**self).take_pending_reply(req_id)
+    fn take_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
+        (**self).take_pending_item(req_id)
     }
 
     #[inline]
@@ -445,7 +461,11 @@ pub trait AsyncDisplay: DisplayBase {
 
     /// Begin sending a raw request to the server. In order to poll the status of this operation, use the
     /// `poll_send_request_raw` function, or just use the `send_request_raw`/`send_request` function.
-    fn begin_send_request_raw(&mut self, req: RequestInfo);
+    fn begin_send_request_raw(
+        &mut self,
+        req: RequestInfo,
+        cx: &mut Context<'_>,
+    ) -> PollOr<(), RequestInfo>;
 
     /// Poll an ongoing raw request operation.
     fn poll_send_request_raw(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<u16>>;
@@ -459,8 +479,12 @@ impl<D: AsyncDisplay + ?Sized> AsyncDisplay for &mut D {
     }
 
     #[inline]
-    fn begin_send_request_raw(&mut self, req: RequestInfo) {
-        (**self).begin_send_request_raw(req)
+    fn begin_send_request_raw(
+        &mut self,
+        req: RequestInfo,
+        cx: &mut Context<'_>,
+    ) -> PollOr<(), RequestInfo> {
+        (**self).begin_send_request_raw(req, cx)
     }
 
     #[inline]
@@ -819,6 +843,53 @@ impl Default for RequestWorkaround {
     fn default() -> Self {
         Self::NoWorkaround
     }
+}
+
+/// Combines `PendingRequest`, `PendingReply`, and `BreadError` into one type, to simplify some of the APIs.
+#[derive(Debug, Clone)]
+pub enum PendingItem {
+    /// A pending request.
+    Request(PendingRequest),
+    /// A pending reply.
+    Reply(PendingReply),
+    /// A pending error.
+    Error(BreadError),
+}
+
+impl PendingItem {
+    /// Convert this into either a `PendingRequest` or `None`.
+    #[inline]
+    pub fn request(self) -> Option<PendingRequest> {
+        match self {
+            PendingItem::Request(pr) => Some(pr),
+            _ => None,
+        }
+    }
+
+    /// Convert this into either a `PendingReply` or `None`.
+    #[inline]
+    pub fn reply(self) -> Option<PendingReply> {
+        match self {
+            PendingItem::Reply(pr) => Some(pr),
+            _ => None,
+        }
+    }
+
+    /// Convert this into either a `BreadError` or `None`.
+    #[inline]
+    pub fn error(self) -> Option<BreadError> {
+        match self {
+            PendingItem::Error(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+/// Utility type to represent a polling result that returns another object if it fails.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PollOr<T, D> {
+    Ready(T),
+    Pending(D),
 }
 
 #[inline]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -27,8 +27,8 @@ mod basic;
 pub(crate) mod bigreq;
 mod cell;
 mod connection;
-pub mod traits;
 
+pub mod traits;
 // "traits" contains some important types.
 pub use traits::{rgb, GcParameters, KeyboardMapping, WindowParameters};
 
@@ -40,6 +40,11 @@ pub use connection::*;
 pub(crate) mod futures;
 #[cfg(feature = "async")]
 pub use futures::*;
+
+#[cfg(feature = "sync")]
+mod sync;
+#[cfg(feature = "sync")]
+pub use sync::*;
 
 pub(crate) mod input;
 pub(crate) mod output;

--- a/src/display/sync/mod.rs
+++ b/src/display/sync/mod.rs
@@ -3,8 +3,42 @@
 mod mutex;
 use mutex::Mutex;
 
+use super::{EXT_KEY_SIZE, PendingRequest, input, output, PendingReply, DisplayBase, Display};
+use crate::{auto::xproto::Setup, xid::{XID, AtomicXidGenerator}, event::Event};
+use concurrent_queue::ConcurrentQueue;
+use core::sync::atomic::{AtomicU64, AtomicU32, AtomicBool};
+use dashmap::DashMap;
+use spinning_top::Spinlock;
+
+#[cfg(feature = "async")]
+use super::{AsyncDisplay, common};
+
 /// A display that uses concurrent primitives in order to allow for thread-safe immutable access to the X
 /// connection.
+/// 
+/// Using a combination of atomic primitives, concurrent queues, concurrent maps, immutable-access connections
+/// and a mutex to serve as an IO lock, `SyncDisplay` allows for immutable usage combined with thread safety. 
+/// It is intended to be put into an `Arc`, synchronous `OnceCell`, or other multithread-accessible location
+/// and used in that way.
+/// 
+/// Note that `SyncDisplay` is generally designed with the idea in mind that one thread will use the connection
+/// at a time. Although non-IO usage (e.g. `DisplayBase` functions) is entirely concurrent, the display will lock
+/// up while one thread uses it and unlock when it is done. If you expect this object to be under high levels of
+/// contention (e.g. multiple threads are attempting to send requests or listen to it at once), it is preferred
+/// to use a `Mutex<BasicDisplay>` or `RwLock<BasicDisplay>` instead. If thread safety is not required, using
+/// `CellDisplay` is much faster than using atomics and locks.
+/// 
+/// ## Construction
+/// 
+/// `SyncDisplay` implements `From<BasicDisplay>`, and this is how it is intended to be constructed.
+/// 
+/// ```rust,no_run
+/// use breadx::display::{DisplayConnection, SyncDisplay};
+/// 
+/// let conn = DisplayConnection::create(None, None).unwrap();
+/// let conn: SyncDisplay<_> = conn.into();
+/// ```
+#[derive(Debug)]
 pub struct SyncDisplay<Conn> {
     // the connection to the server
     connection: Option<Conn>,
@@ -12,20 +46,33 @@ pub struct SyncDisplay<Conn> {
     io_lock: Mutex,
 
     // setup from the server
-    setup: Setup, 
+    setup: Setup,
 
     // xid generator
     xid: AtomicXidGenerator,
 
     // whether or not bigreq is enabled
     bigreq_enabled: bool,
-    
+
     // maximum request length
     max_request_len: usize,
 
     // default screen index
     default_screen: usize,
-   
+
+    // main event queue
+    event_queue: ConcurrentQueue<Event>,
+
+    // map of pending requests, pending replies, and pending errors, combined into one map
+    pending_items: DashMap<u16, PendingItem>,
+
+    // map of special event queues
+    special_event_queues: DashMap<XID, ConcurrentQueue<Event>>,
+
+    // map of extensions to extension opcodes
+    // TODO: this is insert only, there's probably a more optimized version out there
+    extensions: DashMap<[u8; EXT_KEY_SIZE], u8>,
+
     // request number
     request_number: AtomicU64,
 
@@ -35,10 +82,88 @@ pub struct SyncDisplay<Conn> {
     // do we care about zero sized replies?
     checked: AtomicBool,
 
-    // we don't actually spin on these spinlocks, they're just used for mutual access that we can panic if
+    // we don't actually spin on these spinlocks, they're just used for mutable access that we can panic if
     // we get mutual access to it
     #[cfg(feature = "async")]
     wait_buffer: Spinlock<Option<WaitBuffer>>,
     #[cfg(feature = "async")]
-    send_buffer: Spinlock<SendBuffer>, 
+    send_buffer: Spinlock<SendBuffer>,
+}
+
+#[derive(Debug)]
+enum PendingItem {
+    Request(PendingRequest),
+    Reply(PendingReply),
+    Error(crate::BreadError),
+}
+
+impl<Conn> From<BasicDisplay<Conn>> for SyncDisplay<Conn> {
+    #[inline]
+    fn from(bd: BasicDisplay<Conn>) -> Self {
+        let BasicDisplay {
+            connection,
+            setup,
+            bigreq_enabled,
+            max_request_len,
+            xid,
+            default_screen,
+            event_queue,
+            pending_requests,
+            pending_errors,
+            pending_repies,
+            special_event_queues,
+            request_number,
+            wm_protocols_atom,
+            checked,
+            extensions,
+            ..
+        } = bd;
+
+        SyncDisplay {
+            connection,
+            io_lock: Mutex::new(),
+            setup,
+            bigreq_enabled,
+            max_request_len,
+            xid: xid.into(),
+            default_screen,
+            event_queue: into_concurrent_queue(event_queue),
+            pending_items: pending_requests
+                .into_iter()
+                .map(|(k, v)| (k, PendingItem::Request(v)))
+                .chain(
+                    pending_replies
+                        .into_iter()
+                        .map(|(k, v)| (k, PendingItem::Reply(v))),
+                )
+                .chain(
+                    pending_errors
+                        .into_iter()
+                        .map(|(k, v)| (k, PendingItem::Error(v))),
+                )
+                .collect(),
+            special_event_queues: into_concurrent_queue(special_event_queues),
+            extensions: extensions.into_iter().collect(),
+            request_number: AtomicU64::new(request_number),
+            wm_protocols_atom: AtomicU32::new(match wm_protocols_atom {
+                None => 0,
+                Some(wpa) => wpa.get(),
+            }),
+            checked: AtomicBool::new(checked),
+            #[cfg(feature = "async")]
+            wait_buffer: Spinlock::new(None),
+            #[cfg(feature = "async")]
+            send_buffer: Spinlock::new(Default::default()),
+        }
+    }
+}
+
+/// Convenience function to turn an iteratable struct (most often a `VecDeque`) into a `ConcurrentQueue`
+#[inline]
+fn into_concurrent_queue<I: IntoIterator>(i: I) -> ConcurrentQueue<I::Item> {
+    let c = ConcurrentQueue::unbounded();
+    for item in i {
+        c.push(item);
+    }
+    c
 }

--- a/src/display/sync/mod.rs
+++ b/src/display/sync/mod.rs
@@ -1,0 +1,44 @@
+// MIT/Apache2 License
+
+mod mutex;
+use mutex::Mutex;
+
+/// A display that uses concurrent primitives in order to allow for thread-safe immutable access to the X
+/// connection.
+pub struct SyncDisplay<Conn> {
+    // the connection to the server
+    connection: Option<Conn>,
+    // connection lock
+    io_lock: Mutex,
+
+    // setup from the server
+    setup: Setup, 
+
+    // xid generator
+    xid: AtomicXidGenerator,
+
+    // whether or not bigreq is enabled
+    bigreq_enabled: bool,
+    
+    // maximum request length
+    max_request_len: usize,
+
+    // default screen index
+    default_screen: usize,
+   
+    // request number
+    request_number: AtomicU64,
+
+    // interned atoms
+    wm_protocols_atom: AtomicU32,
+
+    // do we care about zero sized replies?
+    checked: AtomicBool,
+
+    // we don't actually spin on these spinlocks, they're just used for mutual access that we can panic if
+    // we get mutual access to it
+    #[cfg(feature = "async")]
+    wait_buffer: Spinlock<Option<WaitBuffer>>,
+    #[cfg(feature = "async")]
+    send_buffer: Spinlock<SendBuffer>, 
+}

--- a/src/display/sync/mutex.rs
+++ b/src/display/sync/mutex.rs
@@ -1,0 +1,66 @@
+// MIT/Apache2 License
+
+use concurrent_queue::ConcurrentQueue;
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+#[cfg(feature = "async")]
+use core::task::{Context, Poll, Waker};
+
+/// A simple implementation of a mutex.
+pub struct Mutex {
+    locked: AtomicBool,
+    wakers: ConcurrentQueue<ThreadOrWaker>,
+}
+
+impl Mutex {
+    /// Try to lock the mutex. If it is locked, lock it a thread.
+    #[inline]
+    pub fn lock(&self) {
+        while self.locked.compare_exchange(false, true, Ordering::AcqRel, Ordering::AcqRel).is_err() {
+            let t = thread::current();
+            self.wakers.push(ThreadOrWaker::Thread(t)).expect("Concurrent queue could not be pushed onto");
+            thread::park();
+        }
+    }
+
+    /// Try to lock the mutex. If it is locked, register the waker.
+    #[cfg(feature = "async")]
+    #[inline]
+    pub fn poll_lock(&self, cx: &mut Context<'_>) -> Poll<()> {
+        match self.locked.compare_exchange(false, true, Ordering::AcqRel, Ordering::AcqRel) {
+            Ok(_) => Poll::Ready(()),
+            Err(_) => { self.wakers.push(ThreadOrWaker::Waker(cx.waker().clone())); Poll::Pending }
+        }
+    }
+
+    /// Unlock the mutex.
+    #[inline]
+    pub fn unlock(&self) {
+        if self.locked.compare_exchange(true, false, Ordering::AcqRel, Ordering::AcqRel).is_ok() {
+            while self.locked.load(Ordering::Acquire) {
+                match self.wakers.pop() {
+                    Ok(waker) => waker.wake(),
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+}
+
+enum ThreadOrWaker {
+    Thread(Thread),
+    #[cfg(feature = "async")]
+    Waker(Waker),
+}
+
+impl ThreadOrWaker {
+    #[inline]
+    pub(crate) fn wake(self) {
+        match self {
+            ThreadOrWaker::Thread(t) => t.wake(),
+            #[cfg(feature = "async")]
+            ThreadOrWaker::Waker(w) => w.wake(),
+        }
+    }
+}

--- a/src/display/sync/mutex.rs
+++ b/src/display/sync/mutex.rs
@@ -7,30 +7,48 @@ use std::thread;
 #[cfg(feature = "async")]
 use core::task::{Context, Poll, Waker};
 
-/// A simple implementation of a mutex.
+/// A simple implementation of non-RAII mutex. It supports both blocking and non-blocking usage, in order to
+/// allow its use by both blocking and non-blocking clients, as well as to facilitate using it without mutex
+/// guards.
 #[derive(Debug)]
 pub struct Mutex {
+    /// Whether or not the mutex is currently locked.
     locked: AtomicBool,
+    /// The list of wakers. Whenever the mutex is unlocked, this queue is drained and all of the wakers are
+    /// woken until the mutex is locked again. It is less efficient than most contemporary mutex implementations,
+    /// but it has the advantage of not needing an RAII guard. In addition, unparkers on most platforms are
+    /// backed by either `Mutex`es or other operating-specific ways of parking the thread (IIRC futexes on Linux
+    /// and events on Windows), so even in the worst case it should just act as a `Mutex` with a slight amount of
+    /// overhead.
     wakers: ConcurrentQueue<ThreadOrWaker>,
 }
 
 impl Mutex {
     /// Create a new mutex.
     #[inline]
-    pub fn new() -> Self { Self { locked: AtomicBool::new(false), wakers: ConcurrentQueue::unbounded() } }
+    pub fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            wakers: ConcurrentQueue::unbounded(),
+        }
+    }
 
     /// Try to lock the mutex. If it is locked, lock it a thread.
     #[inline]
     pub fn lock(&self) {
+        // until we've successfully locked the mutex...
         while self
             .locked
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::AcqRel)
             .is_err()
         {
+            // park the current thread
             let t = thread::current();
+            // push an unparker into the wakers queue
             self.wakers
                 .push(ThreadOrWaker::Thread(t))
                 .expect("Concurrent queue could not be pushed onto");
+            // note: this loop does defeat spurious wakeups
             thread::park();
         }
     }
@@ -39,12 +57,16 @@ impl Mutex {
     #[cfg(feature = "async")]
     #[inline]
     pub fn poll_lock(&self, cx: &mut Context<'_>) -> Poll<()> {
+        // try to lock the mutex
         match self
             .locked
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::AcqRel)
         {
+            // if we do, great!
             Ok(_) => Poll::Ready(()),
             Err(_) => {
+                // if we don't, push the context's waker into the mutex list and wake it when the mutex is
+                // open
                 self.wakers.push(ThreadOrWaker::Waker(cx.waker().clone()));
                 Poll::Pending
             }
@@ -54,12 +76,17 @@ impl Mutex {
     /// Unlock the mutex.
     #[inline]
     pub fn unlock(&self) {
+        // unlock the mutex
         if self
             .locked
             .compare_exchange(true, false, Ordering::AcqRel, Ordering::AcqRel)
             .is_ok()
         {
+            // in the course of waking all of the wakers, they will probably try to lock the mutex. if the mutex
+            // is locked after a wake operation, there's no real need to keep waking more wakers, as they'll
+            // just be wastefully added back onto the queue
             while self.locked.load(Ordering::Acquire) {
+                // if we can, wake a waker
                 match self.wakers.pop() {
                     Ok(waker) => waker.wake(),
                     Err(_) => break,
@@ -69,17 +96,22 @@ impl Mutex {
     }
 }
 
+/// Wakes a task. Either an unparker for a thread, or a waker for an async task. For non-async users, this is
+/// a (hopefully) no-op wrapper around the unparker.
 enum ThreadOrWaker {
+    /// A thread handle, used to unpark a given thread.
     Thread(Thread),
+    /// A waker, used to wake a given async task.
     #[cfg(feature = "async")]
     Waker(Waker),
 }
 
 impl ThreadOrWaker {
+    /// Wake either the thread or the async context that this waker is designated to wake.
     #[inline]
     pub(crate) fn wake(self) {
         match self {
-            ThreadOrWaker::Thread(t) => t.wake(),
+            ThreadOrWaker::Thread(t) => t.unpark(),
             #[cfg(feature = "async")]
             ThreadOrWaker::Waker(w) => w.wake(),
         }

--- a/src/display/types.rs
+++ b/src/display/types.rs
@@ -1,0 +1,205 @@
+// MIT/Apache2 License
+
+use crate::BreadError;
+
+/// Either a pending request, a pending reply, or a pending error.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Exchange {
+    Request(PendingRequest),
+    Reply(PendingReply),
+    Error(BreadError),
+}
+
+impl Exchange {
+
+}
+
+/// Request information, monomorphized from the Request trait.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RequestInfo {
+    pub(crate) data: TinyVec<[u8; 32]>,
+    pub(crate) fds: Vec<Fd>,
+    pub(crate) zero_sized_reply: bool,
+    pub(crate) opcode: u8,
+    pub(crate) extension: Option<&'static str>,
+    pub(crate) expects_fds: bool,
+    pub(crate) discard_reply: bool,
+    pub(crate) sequence: Option<u16>,
+}
+
+impl RequestInfo {
+    /// Generate a `RequestInfo` given a specific `Request` to generate from.
+    #[inline]
+    pub fn from_request<R: Request>(mut req: R, use_bigreq: bool, max_request_len: usize) -> Self {
+        const SHORT_REQUEST_LIMIT: usize = (u16::MAX as usize) * 4;
+        debug_assert!(use_bigreq || max_request_len <= SHORT_REQUEST_LIMIT);
+
+        // TODO: somehow write using uninitialzied data
+        let mut data = iter::repeat(0)
+            .take(req.size())
+            .collect::<TinyVec<[u8; 32]>>();
+        let mut len = req.as_bytes(&mut data);
+
+        // make sure it's aligned to a multiple of 4
+        len = (len + 3) & (!0x03);
+        expand_or_truncate_to_length(&mut data, len);
+
+        // note: we assume max_request_len is already normalized
+        assert!(
+            max_request_len >= len,
+            "Request's size was larger than the maximum request length"
+        );
+
+        // If we fit in the short request limit, third and fourth bytes need to be length
+        let x_len = len / 4;
+        log::trace!("xlen is {}", x_len);
+        if use_bigreq {
+            let length_bytes = ((x_len + 1) as u32).to_ne_bytes();
+            data = match data {
+                TinyVec::Inline(data) => BigreqIterator {
+                    inner: data.into_iter(),
+                    length_bytes,
+                    cursor: 0,
+                }
+                .collect(),
+                TinyVec::Heap(data) => BigreqIterator {
+                    inner: data.into_iter(),
+                    length_bytes,
+                    cursor: 0,
+                }
+                .collect(),
+            };
+        } else {
+            let len_bytes = (x_len as u16).to_ne_bytes();
+            data[2] = len_bytes[0];
+            data[3] = len_bytes[1];
+        }
+
+        RequestInfo {
+            data,
+            fds: match req.file_descriptors() {
+                Some(fd) => mem::take(fd),
+                None => Vec::new(),
+            },
+            zero_sized_reply: mem::size_of::<R::Reply>() == 0,
+            opcode: R::OPCODE,
+            extension: R::EXTENSION,
+            expects_fds: R::REPLY_EXPECTS_FDS,
+            discard_reply: false,
+            sequence: None,
+        }
+    }
+
+    /// Set the sequence number for this `RequestInfo`.
+    #[inline]
+    pub(crate) fn set_sequence(&mut self, seq: u16) {
+        self.sequence = Some(seq);
+    }
+}
+
+struct BigreqIterator<I> {
+    inner: I,
+    cursor: usize,
+    length_bytes: [u8; 4],
+}
+
+impl<I: Iterator<Item = u8>> Iterator for BigreqIterator<I> {
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<u8> {
+        let res = match self.cursor {
+            // 2..4
+            2..=3 => {
+                self.inner.next();
+                Some(0)
+            }
+            // 4..8
+            4..=7 => Some(self.length_bytes[self.cursor - 4]),
+            _ => self.inner.next(),
+        };
+
+        self.cursor += 1;
+        res
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lo, hi) = self.inner.size_hint();
+        (lo + 4, hi.map(|hi| hi + 4))
+    }
+}
+
+impl<I: Iterator<Item = u8> + FusedIterator> FusedIterator for BigreqIterator<I> {}
+
+impl<I: Iterator<Item = u8> + ExactSizeIterator> ExactSizeIterator for BigreqIterator<I> {}
+
+/// A reply, pending returning from the display.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PendingReply {
+    pub data: TinyVec<[u8; 32]>,
+    pub fds: Box<[Fd]>,
+}
+
+/// A cookie for a request.
+///
+/// Requests usually take time to resolve into replies. Therefore, the `Display::send_request` method returns
+/// the `RequestCookie`, which is later used to block (or await) for the request's eventual result.
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Default, Eq, Hash)]
+#[repr(transparent)]
+pub struct RequestCookie<R: Request> {
+    sequence: u16,
+    _phantom: PhantomData<Option<R::Reply>>,
+}
+
+impl<R: Request> fmt::Debug for RequestCookie<R> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RequestCookie")
+            .field("sequence", &self.sequence)
+            .finish()
+    }
+}
+
+impl<R: Request> RequestCookie<R> {
+    #[inline]
+    pub(crate) fn from_sequence(sequence: u16) -> Self {
+        Self {
+            sequence,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn sequence(self) -> u16 {
+        self.sequence
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PendingRequest {
+    pub request: u16,
+    pub flags: PendingRequestFlags,
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct PendingRequestFlags {
+    pub discard_reply: bool,
+    pub checked: bool,
+    pub expects_fds: bool,
+    pub workaround: RequestWorkaround,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum RequestWorkaround {
+    NoWorkaround,
+    GlxFbconfigBug,
+}
+
+impl Default for RequestWorkaround {
+    #[inline]
+    fn default() -> Self {
+        Self::NoWorkaround
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 //! This module provides structures used in error handling of `breadx` functions.
 
 use alloc::{borrow::Cow, string::String, sync::Arc};
-use core::{fmt, ops::Deref};
+use core::{convert::Infallible, fmt, ops::Deref};
 #[cfg(feature = "std")]
 use std::{error::Error as StdError, io::Error as IoError};
 
@@ -71,6 +71,13 @@ impl From<IoError> for BreadError {
     #[inline]
     fn from(io: IoError) -> Self {
         Self::Io(Arc::new(io))
+    }
+}
+
+impl From<Infallible> for BreadError {
+    #[inline]
+    fn from(_i: Infallible) -> Self {
+        panic!("Infallible")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,14 @@
 //!           than building a connection itself.
 //! * `async` - Enables the `_async` suffix family of functions. These functions and methods are similar
 //!             to their blocking variants, but they use non-blocking variants of network calls. This uses
-//!             the [`async_net`](https://crates.io/crates/async-net) crate to provide non-blocking calls.
+//!             the [`async-io`](https://crates.io/crates/async-io) crate to provide non-blocking calls.
 //!             However, it nearly triples the size of this package's dependency tree.
-//! * `image-support` - Coming soon.
-//! * `nightly-min-specialization` - Coming soon.
-//! * `parallel` - Uses the [`rayon`](https://crates.io/crates/rayon) crate to parallelize computationally
-//!                expensive operations.
+//! * `image-support` - Adds the `from_image` method to the `Image` class, allowing one to convert a struct of
+//!                     type `image::Image` from the [`image`](https://crates.io/crates/image) crate into this
+//!                     image.
+//! * `sync-display` - Enables the `SyncDisplay` struct, which allows usage of the display in thread-safe
+//!                    contexts. However, it does require importing more dependencies (although some of these
+//!                    dependencies overlap with those of the `async` feature).
 
 #![deny(deprecated)]
 #![forbid(unsafe_code)]

--- a/src/render/display.rs
+++ b/src/render/display.rs
@@ -12,8 +12,7 @@ use crate::{
         xproto::{Drawable, Setup, Visualtype},
     },
     display::{
-        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingItem, PendingReply,
-        PendingRequest, PollOr, RequestInfo, EXT_KEY_SIZE,
+        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingItem,  RequestInfo, EXT_KEY_SIZE,
     },
     event::Event,
     BreadError, XID,
@@ -22,7 +21,7 @@ use alloc::boxed::Box;
 use core::num::NonZeroU32;
 
 #[cfg(feature = "async")]
-use crate::display::AsyncDisplay;
+use crate::display::{PollOr, AsyncDisplay};
 #[cfg(feature = "async")]
 use core::task::{Context, Poll};
 
@@ -276,7 +275,7 @@ impl<Dpy: DisplayBase> DisplayBase for RenderDisplay<Dpy> {
     }
 
     #[inline]
-    fn get_pending_item(&self, req_id: u16) -> Option<PendingItem> {
+    fn get_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
         self.inner.get_pending_item(req_id)
     }
 
@@ -380,38 +379,18 @@ where
     }
 
     #[inline]
-    fn add_pending_request(&mut self, req_id: u16, pereq: PendingRequest) {
-        self.inner().add_pending_request(req_id, pereq)
+    fn add_pending_item(&mut self, req_id: u16, pereq: PendingItem) {
+        self.inner().add_pending_item(req_id, pereq)
     }
 
     #[inline]
-    fn get_pending_request(&self, req_id: u16) -> Option<PendingRequest> {
-        self.inner().get_pending_request(req_id)
+    fn get_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
+        self.inner().get_pending_item(req_id)
     }
 
     #[inline]
-    fn take_pending_request(&mut self, req_id: u16) -> Option<PendingRequest> {
-        self.inner().take_pending_request(req_id)
-    }
-
-    #[inline]
-    fn add_pending_error(&mut self, req_id: u16, error: BreadError) {
-        self.inner().add_pending_error(req_id, error);
-    }
-
-    #[inline]
-    fn check_for_pending_error(&mut self, req_id: u16) -> crate::Result<()> {
-        self.inner().check_for_pending_error(req_id)
-    }
-
-    #[inline]
-    fn add_pending_reply(&mut self, req_id: u16, reply: PendingReply) {
-        self.inner().add_pending_reply(req_id, reply);
-    }
-
-    #[inline]
-    fn take_pending_reply(&mut self, req_id: u16) -> Option<PendingReply> {
-        self.inner().take_pending_reply(req_id)
+    fn take_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
+        self.inner().take_pending_item(req_id)
     }
 
     #[inline]
@@ -555,7 +534,7 @@ impl<Dpy: Display> RenderDisplay<Dpy> {
         mut dpy: Dpy,
         client_major_version: u32,
         client_minor_version: u32,
-    ) -> Result<Self, (Dpy, crate::BreadError)> {
+    ) -> Result<Self, (Dpy, BreadError)> {
         #[inline]
         fn xrender_info<Dpy: Display>(
             dpy: &mut Dpy,

--- a/src/render/display.rs
+++ b/src/render/display.rs
@@ -12,7 +12,8 @@ use crate::{
         xproto::{Drawable, Setup, Visualtype},
     },
     display::{
-        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingItem,  RequestInfo, EXT_KEY_SIZE,
+        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingItem, RequestInfo,
+        EXT_KEY_SIZE,
     },
     event::Event,
     BreadError, XID,
@@ -21,7 +22,7 @@ use alloc::boxed::Box;
 use core::num::NonZeroU32;
 
 #[cfg(feature = "async")]
-use crate::display::{PollOr, AsyncDisplay};
+use crate::display::{AsyncDisplay, PollOr};
 #[cfg(feature = "async")]
 use core::task::{Context, Poll};
 

--- a/src/render/display.rs
+++ b/src/render/display.rs
@@ -12,8 +12,8 @@ use crate::{
         xproto::{Drawable, Setup, Visualtype},
     },
     display::{
-        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingReply, PendingRequest,
-        RequestInfo, EXT_KEY_SIZE,
+        generate_xid, prelude::*, Display, DisplayBase, DisplayExt, PendingItem, PendingReply,
+        PendingRequest, PollOr, RequestInfo, EXT_KEY_SIZE,
     },
     event::Event,
     BreadError, XID,
@@ -271,38 +271,18 @@ impl<Dpy: DisplayBase> DisplayBase for RenderDisplay<Dpy> {
     }
 
     #[inline]
-    fn add_pending_request(&mut self, req_id: u16, pereq: PendingRequest) {
-        self.inner.add_pending_request(req_id, pereq)
+    fn add_pending_item(&mut self, req_id: u16, item: PendingItem) {
+        self.inner.add_pending_item(req_id, item)
     }
 
     #[inline]
-    fn get_pending_request(&self, req_id: u16) -> Option<PendingRequest> {
-        self.inner.get_pending_request(req_id)
+    fn get_pending_item(&self, req_id: u16) -> Option<PendingItem> {
+        self.inner.get_pending_item(req_id)
     }
 
     #[inline]
-    fn take_pending_request(&mut self, req_id: u16) -> Option<PendingRequest> {
-        self.inner.take_pending_request(req_id)
-    }
-
-    #[inline]
-    fn add_pending_error(&mut self, req_id: u16, error: BreadError) {
-        self.inner.add_pending_error(req_id, error);
-    }
-
-    #[inline]
-    fn check_for_pending_error(&mut self, req_id: u16) -> crate::Result<()> {
-        self.inner.check_for_pending_error(req_id)
-    }
-
-    #[inline]
-    fn add_pending_reply(&mut self, req_id: u16, reply: PendingReply) {
-        self.inner.add_pending_reply(req_id, reply);
-    }
-
-    #[inline]
-    fn take_pending_reply(&mut self, req_id: u16) -> Option<PendingReply> {
-        self.inner.take_pending_reply(req_id)
+    fn take_pending_item(&mut self, req_id: u16) -> Option<PendingItem> {
+        self.inner.take_pending_item(req_id)
     }
 
     #[inline]
@@ -529,8 +509,12 @@ impl<Dpy: AsyncDisplay> AsyncDisplay for RenderDisplay<Dpy> {
     }
 
     #[inline]
-    fn begin_send_request_raw(&mut self, req: RequestInfo) {
-        self.inner.begin_send_request_raw(req)
+    fn begin_send_request_raw(
+        &mut self,
+        req: RequestInfo,
+        cx: &mut Context<'_>,
+    ) -> PollOr<(), RequestInfo> {
+        self.inner.begin_send_request_raw(req, cx)
     }
 
     #[inline]
@@ -550,8 +534,12 @@ where
     }
 
     #[inline]
-    fn begin_send_request_raw(&mut self, req: RequestInfo) {
-        self.inner().begin_send_request_raw(req)
+    fn begin_send_request_raw(
+        &mut self,
+        req: RequestInfo,
+        cx: &mut Context<'_>,
+    ) -> PollOr<(), RequestInfo> {
+        self.inner().begin_send_request_raw(req, cx)
     }
 
     #[inline]

--- a/src/xid.rs
+++ b/src/xid.rs
@@ -3,7 +3,7 @@
 use crate::auto;
 use core::cell::Cell;
 
-#[cfg(feature = "sync_display")]
+#[cfg(feature = "sync-display")]
 use core::sync::atomic::{AtomicU32, Ordering};
 
 /// An X11 ID.

--- a/src/xid.rs
+++ b/src/xid.rs
@@ -3,6 +3,9 @@
 use crate::auto;
 use core::cell::Cell;
 
+#[cfg(feature = "sync_display")]
+use core::sync::atomic::{AtomicU32, Ordering};
+
 /// An X11 ID.
 #[allow(clippy::upper_case_acronyms)]
 pub type XID = u32;
@@ -146,5 +149,82 @@ impl CellXidGenerator {
         }
 
         Some(self.eval_in_place())
+    }
+}
+
+/// XID Generator, but implemented using atomics.
+#[cfg(feature = "sync-display")]
+#[derive(Debug)]
+pub struct AtomicXidGenerator {
+    pub last: AtomicU32,
+    pub max: AtomicU32,
+    pub inc: XID,
+    pub base: XID,
+    mask: XID,
+}
+
+#[cfg(feature = "sync-display")]
+impl From<XidGenerator> for AtomicXidGenerator {
+    #[inline]
+    fn from(x: XidGenerator) -> Self {
+        let XidGenerator {
+            last,
+            max,
+            inc,
+            base,
+            mask,
+        } = x;
+        Self {
+            last: AtomicU32::new(last),
+            max: AtomicU32::new(max),
+            inc,
+            base,
+            mask,
+        }
+    }
+}
+
+#[cfg(feature = "sync-display")]
+impl AtomicXidGenerator {
+    #[must_use]
+    #[inline]
+    pub const fn new(base: XID, mask: XID) -> Self {
+        Self {
+            last: AtomicU32::new(0),
+            max: AtomicU32::new(0),
+            base,
+            inc: mask & mask.wrapping_neg(),
+            mask,
+        }
+    }
+
+    #[inline]
+    pub fn eval_in_place(&self) -> XID {
+        self.last.load(Ordering::SeqCst) | self.base
+    }
+
+    #[inline]
+    pub fn next_xid(&self) -> Option<XID> {
+        let mut last = self.last.load(Ordering::SeqCst);
+        if last
+            >= self
+                .max
+                .load(Ordering::SeqCst)
+                .wrapping_sub(self.inc)
+                .wrapping_add(1)
+        {
+            assert_eq!(last, self.max.load(Ordering::Relaxed));
+            if last == 0 {
+                self.max.store(self.mask, Ordering::SeqCst);
+                self.last.store(self.inc, Ordering::SeqCst);
+            } else {
+                return None;
+            }
+        } else {
+            last = last.wrapping_add(self.inc);
+            self.last.store(last, Ordering::SeqCst);
+        }
+
+        Some(last | self.base)
     }
 }


### PR DESCRIPTION
This PR adds the `SyncDisplay` object, which allows concurrent, thread-safe, and immutable access at the cost of some overhead. In addition, the rest of the API was modified to allow for `SyncDisplay` to exist.

Also, I fully implemented the `image-support` feature. The groundwork was already there, I just had to implement it.